### PR TITLE
Add "version: PATH" to pull pyright from $PATH

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,4 +88,4 @@ jobs:
       - uses: ./
         with:
           working-directory: ./smoke-test
-          version: path
+          version: PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,3 +81,11 @@ jobs:
       - uses: ./
         with:
           working-directory: ./smoke-test
+
+      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+      - run: pip install pyright
+
+      - uses: ./
+        with:
+          working-directory: ./smoke-test
+          version: path

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ GitHub action for [pyright](https://github.com/microsoft/pyright). Featuring:
 inputs:
   # Options for pyright-action
   version:
-    description: 'Version of pyright to run, or "path" to use pyright from $PATH. If neither version nor pylance-version are specified, the latest version will be used.'
+    description: 'Version of pyright to run, or "PATH" to use pyright from $PATH. If neither version nor pylance-version are specified, the latest version will be used.'
     required: false
   pylance-version:
     description: 'Version of pylance whose pyright version should be run. Can be latest-release, latest-prerelease, or a specific pylance version. Ignored if version option is specified.'
@@ -143,7 +143,31 @@ poetry's python binary is on `$PATH`:
 - uses: jakebailey/pyright-action@v2
 ```
 
-## Keeping Pyright and Pylance in sync
+## Providing a pyright version sourced from preexisting dependencies
+
+The `version` input only accepts "latest" or a specific version number. However,
+there are many ways to use specify a version of `pyright` derived from other
+tools.
+
+### Using pyright from `$PATH`
+
+If you have `pyright` installed in your environment, e.g. via the `pyright` PyPI
+package, specify `version: PATH` to use the version that's on `$PATH`.
+
+```yml
+- run: |
+    python -m venv .venv
+    source .venv/bin/activate
+    pip install -r dev-requirements.txt # includes pyright
+
+- run: echo "$PWD/.venv/bin" >> $GITHUB_PATH
+
+- uses: jakebailey/pyright-action@v2
+  with:
+    version: PATH
+```
+
+### Keeping Pyright and Pylance in sync
 
 If you use Pylance as your language server, you'll likely want pyright-action to
 use the same version of `pyright` that Pylance does. The `pylance-version`

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ GitHub action for [pyright](https://github.com/microsoft/pyright). Featuring:
 inputs:
   # Options for pyright-action
   version:
-    description: 'Version of pyright to run. If neither version nor pylance-version are specified, the latest version will be used.'
+    description: 'Version of pyright to run, or "path" to use pyright from $PATH. If neither version nor pylance-version are specified, the latest version will be used.'
     required: false
   pylance-version:
     description: 'Version of pylance whose pyright version should be run. Can be latest-release, latest-prerelease, or a specific pylance version. Ignored if version option is specified.'

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ branding:
 inputs:
   # Options for pyright-action
   version:
-    description: 'Version of pyright to run, or "path" to use pyright from $PATH. If neither version nor pylance-version are specified, the latest version will be used.'
+    description: 'Version of pyright to run, or "PATH" to use pyright from $PATH. If neither version nor pylance-version are specified, the latest version will be used.'
     required: false
   pylance-version:
     description: 'Version of pylance whose pyright version should be run. Can be latest-release, latest-prerelease, or a specific pylance version. Ignored if version option is specified.'

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ branding:
 inputs:
   # Options for pyright-action
   version:
-    description: 'Version of pyright to run. If neither version nor pylance-version are specified, the latest version will be used.'
+    description: 'Version of pyright to run, or "path" to use pyright from $PATH. If neither version nor pylance-version are specified, the latest version will be used.'
     required: false
   pylance-version:
     description: 'Version of pylance whose pyright version should be run. Can be latest-release, latest-prerelease, or a specific pylance version. Ignored if version option is specified.'

--- a/dist/index.js
+++ b/dist/index.js
@@ -2546,23 +2546,23 @@ var require_toml_parser = __commonJS({
       [CHAR_QUOT]: '"',
       [CHAR_BSOL]: "\\"
     };
-    function isDigit(cp2) {
-      return cp2 >= CHAR_0 && cp2 <= CHAR_9;
+    function isDigit(cp3) {
+      return cp3 >= CHAR_0 && cp3 <= CHAR_9;
     }
-    function isHexit(cp2) {
-      return cp2 >= CHAR_A && cp2 <= CHAR_F || cp2 >= CHAR_a && cp2 <= CHAR_f || cp2 >= CHAR_0 && cp2 <= CHAR_9;
+    function isHexit(cp3) {
+      return cp3 >= CHAR_A && cp3 <= CHAR_F || cp3 >= CHAR_a && cp3 <= CHAR_f || cp3 >= CHAR_0 && cp3 <= CHAR_9;
     }
-    function isBit(cp2) {
-      return cp2 === CHAR_1 || cp2 === CHAR_0;
+    function isBit(cp3) {
+      return cp3 === CHAR_1 || cp3 === CHAR_0;
     }
-    function isOctit(cp2) {
-      return cp2 >= CHAR_0 && cp2 <= CHAR_7;
+    function isOctit(cp3) {
+      return cp3 >= CHAR_0 && cp3 <= CHAR_7;
     }
-    function isAlphaNumQuoteHyphen(cp2) {
-      return cp2 >= CHAR_A && cp2 <= CHAR_Z || cp2 >= CHAR_a && cp2 <= CHAR_z || cp2 >= CHAR_0 && cp2 <= CHAR_9 || cp2 === CHAR_APOS || cp2 === CHAR_QUOT || cp2 === CHAR_LOWBAR || cp2 === CHAR_HYPHEN;
+    function isAlphaNumQuoteHyphen(cp3) {
+      return cp3 >= CHAR_A && cp3 <= CHAR_Z || cp3 >= CHAR_a && cp3 <= CHAR_z || cp3 >= CHAR_0 && cp3 <= CHAR_9 || cp3 === CHAR_APOS || cp3 === CHAR_QUOT || cp3 === CHAR_LOWBAR || cp3 === CHAR_HYPHEN;
     }
-    function isAlphaNumHyphen(cp2) {
-      return cp2 >= CHAR_A && cp2 <= CHAR_Z || cp2 >= CHAR_a && cp2 <= CHAR_z || cp2 >= CHAR_0 && cp2 <= CHAR_9 || cp2 === CHAR_LOWBAR || cp2 === CHAR_HYPHEN;
+    function isAlphaNumHyphen(cp3) {
+      return cp3 >= CHAR_A && cp3 <= CHAR_Z || cp3 >= CHAR_a && cp3 <= CHAR_z || cp3 >= CHAR_0 && cp3 <= CHAR_9 || cp3 === CHAR_LOWBAR || cp3 === CHAR_HYPHEN;
     }
     var _type = Symbol("type");
     var _declared = Symbol("declared");
@@ -5139,7 +5139,7 @@ var require_io = __commonJS({
     var assert_1 = require("assert");
     var path3 = __importStar(require("path"));
     var ioUtil = __importStar(require_io_util());
-    function cp2(source, dest, options = {}) {
+    function cp3(source, dest, options = {}) {
       return __awaiter(this, void 0, void 0, function* () {
         const { force, recursive, copySourceDirectory } = readCopyOptions(options);
         const destStat = (yield ioUtil.exists(dest)) ? yield ioUtil.stat(dest) : null;
@@ -5165,7 +5165,7 @@ var require_io = __commonJS({
         }
       });
     }
-    exports2.cp = cp2;
+    exports2.cp = cp3;
     function mv(source, dest, options = {}) {
       return __awaiter(this, void 0, void 0, function* () {
         if (yield ioUtil.exists(dest)) {
@@ -5214,13 +5214,13 @@ var require_io = __commonJS({
       });
     }
     exports2.mkdirP = mkdirP;
-    function which(tool, check) {
+    function which2(tool, check) {
       return __awaiter(this, void 0, void 0, function* () {
         if (!tool) {
           throw new Error("parameter 'tool' is required");
         }
         if (check) {
-          const result = yield which(tool, false);
+          const result = yield which2(tool, false);
           if (!result) {
             if (ioUtil.IS_WINDOWS) {
               throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.`);
@@ -5237,7 +5237,7 @@ var require_io = __commonJS({
         return "";
       });
     }
-    exports2.which = which;
+    exports2.which = which2;
     function findInPath(tool) {
       return __awaiter(this, void 0, void 0, function* () {
         if (!tool) {
@@ -6542,7 +6542,7 @@ var require_manifest = __commonJS({
     var semver = __importStar(require_semver2());
     var core_1 = require_core();
     var os = require("os");
-    var cp2 = require("child_process");
+    var cp3 = require("child_process");
     var fs2 = require("fs");
     function _findMatch(versionSpec, stable, candidates, archFilter) {
       return __awaiter(this, void 0, void 0, function* () {
@@ -6586,7 +6586,7 @@ var require_manifest = __commonJS({
       const plat = os.platform();
       let version3 = "";
       if (plat === "darwin") {
-        version3 = cp2.execSync("sw_vers -productVersion").toString();
+        version3 = cp3.execSync("sw_vers -productVersion").toString();
       } else if (plat === "linux") {
         const lsbContents = module2.exports._readLinuxVersionFile();
         if (lsbContents) {
@@ -6992,10 +6992,10 @@ var require_toolrunner = __commonJS({
               return reject(new Error(`The cwd: ${this.options.cwd} does not exist!`));
             }
             const fileName = this._getSpawnFileName();
-            const cp2 = child.spawn(fileName, this._getSpawnArgs(optionsNonNull), this._getSpawnOptions(this.options, fileName));
+            const cp3 = child.spawn(fileName, this._getSpawnArgs(optionsNonNull), this._getSpawnOptions(this.options, fileName));
             let stdbuffer = "";
-            if (cp2.stdout) {
-              cp2.stdout.on("data", (data) => {
+            if (cp3.stdout) {
+              cp3.stdout.on("data", (data) => {
                 if (this.options.listeners && this.options.listeners.stdout) {
                   this.options.listeners.stdout(data);
                 }
@@ -7010,8 +7010,8 @@ var require_toolrunner = __commonJS({
               });
             }
             let errbuffer = "";
-            if (cp2.stderr) {
-              cp2.stderr.on("data", (data) => {
+            if (cp3.stderr) {
+              cp3.stderr.on("data", (data) => {
                 state.processStderr = true;
                 if (this.options.listeners && this.options.listeners.stderr) {
                   this.options.listeners.stderr(data);
@@ -7027,19 +7027,19 @@ var require_toolrunner = __commonJS({
                 });
               });
             }
-            cp2.on("error", (err) => {
+            cp3.on("error", (err) => {
               state.processError = err.message;
               state.processExited = true;
               state.processClosed = true;
               state.CheckComplete();
             });
-            cp2.on("exit", (code) => {
+            cp3.on("exit", (code) => {
               state.processExitCode = code;
               state.processExited = true;
               this._debug(`Exit code ${code} received from tool '${this.toolPath}'`);
               state.CheckComplete();
             });
-            cp2.on("close", (code) => {
+            cp3.on("close", (code) => {
               state.processExitCode = code;
               state.processExited = true;
               state.processClosed = true;
@@ -7053,7 +7053,7 @@ var require_toolrunner = __commonJS({
               if (errbuffer.length > 0) {
                 this.emit("errline", errbuffer);
               }
-              cp2.removeAllListeners();
+              cp3.removeAllListeners();
               if (error) {
                 reject(error);
               } else {
@@ -7061,10 +7061,10 @@ var require_toolrunner = __commonJS({
               }
             });
             if (this.options.input) {
-              if (!cp2.stdin) {
+              if (!cp3.stdin) {
                 throw new Error("child process missing stdin");
               }
-              cp2.stdin.end(this.options.input);
+              cp3.stdin.end(this.options.input);
             }
           }));
         });
@@ -7948,9 +7948,264 @@ var require_tool_cache = __commonJS({
   }
 });
 
+// node_modules/.pnpm/isexe@3.1.1/node_modules/isexe/dist/cjs/posix.js
+var require_posix = __commonJS({
+  "node_modules/.pnpm/isexe@3.1.1/node_modules/isexe/dist/cjs/posix.js"(exports2) {
+    "use strict";
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.sync = exports2.isexe = void 0;
+    var fs_1 = require("fs");
+    var promises_1 = require("fs/promises");
+    var isexe = async (path3, options = {}) => {
+      const { ignoreErrors = false } = options;
+      try {
+        return checkStat(await (0, promises_1.stat)(path3), options);
+      } catch (e) {
+        const er = e;
+        if (ignoreErrors || er.code === "EACCES")
+          return false;
+        throw er;
+      }
+    };
+    exports2.isexe = isexe;
+    var sync = (path3, options = {}) => {
+      const { ignoreErrors = false } = options;
+      try {
+        return checkStat((0, fs_1.statSync)(path3), options);
+      } catch (e) {
+        const er = e;
+        if (ignoreErrors || er.code === "EACCES")
+          return false;
+        throw er;
+      }
+    };
+    exports2.sync = sync;
+    var checkStat = (stat, options) => stat.isFile() && checkMode(stat, options);
+    var checkMode = (stat, options) => {
+      const myUid = options.uid ?? process.getuid?.();
+      const myGroups = options.groups ?? process.getgroups?.() ?? [];
+      const myGid = options.gid ?? process.getgid?.() ?? myGroups[0];
+      if (myUid === void 0 || myGid === void 0) {
+        throw new Error("cannot get uid or gid");
+      }
+      const groups = /* @__PURE__ */ new Set([myGid, ...myGroups]);
+      const mod = stat.mode;
+      const uid = stat.uid;
+      const gid = stat.gid;
+      const u = parseInt("100", 8);
+      const g = parseInt("010", 8);
+      const o = parseInt("001", 8);
+      const ug = u | g;
+      return !!(mod & o || mod & g && groups.has(gid) || mod & u && uid === myUid || mod & ug && myUid === 0);
+    };
+  }
+});
+
+// node_modules/.pnpm/isexe@3.1.1/node_modules/isexe/dist/cjs/win32.js
+var require_win32 = __commonJS({
+  "node_modules/.pnpm/isexe@3.1.1/node_modules/isexe/dist/cjs/win32.js"(exports2) {
+    "use strict";
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.sync = exports2.isexe = void 0;
+    var fs_1 = require("fs");
+    var promises_1 = require("fs/promises");
+    var isexe = async (path3, options = {}) => {
+      const { ignoreErrors = false } = options;
+      try {
+        return checkStat(await (0, promises_1.stat)(path3), path3, options);
+      } catch (e) {
+        const er = e;
+        if (ignoreErrors || er.code === "EACCES")
+          return false;
+        throw er;
+      }
+    };
+    exports2.isexe = isexe;
+    var sync = (path3, options = {}) => {
+      const { ignoreErrors = false } = options;
+      try {
+        return checkStat((0, fs_1.statSync)(path3), path3, options);
+      } catch (e) {
+        const er = e;
+        if (ignoreErrors || er.code === "EACCES")
+          return false;
+        throw er;
+      }
+    };
+    exports2.sync = sync;
+    var checkPathExt = (path3, options) => {
+      const { pathExt = process.env.PATHEXT || "" } = options;
+      const peSplit = pathExt.split(";");
+      if (peSplit.indexOf("") !== -1) {
+        return true;
+      }
+      for (let i = 0; i < peSplit.length; i++) {
+        const p = peSplit[i].toLowerCase();
+        const ext = path3.substring(path3.length - p.length).toLowerCase();
+        if (p && ext === p) {
+          return true;
+        }
+      }
+      return false;
+    };
+    var checkStat = (stat, path3, options) => stat.isFile() && checkPathExt(path3, options);
+  }
+});
+
+// node_modules/.pnpm/isexe@3.1.1/node_modules/isexe/dist/cjs/options.js
+var require_options = __commonJS({
+  "node_modules/.pnpm/isexe@3.1.1/node_modules/isexe/dist/cjs/options.js"(exports2) {
+    "use strict";
+    Object.defineProperty(exports2, "__esModule", { value: true });
+  }
+});
+
+// node_modules/.pnpm/isexe@3.1.1/node_modules/isexe/dist/cjs/index.js
+var require_cjs = __commonJS({
+  "node_modules/.pnpm/isexe@3.1.1/node_modules/isexe/dist/cjs/index.js"(exports2) {
+    "use strict";
+    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+      if (k2 === void 0)
+        k2 = k;
+      var desc = Object.getOwnPropertyDescriptor(m, k);
+      if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+        desc = { enumerable: true, get: function() {
+          return m[k];
+        } };
+      }
+      Object.defineProperty(o, k2, desc);
+    } : function(o, m, k, k2) {
+      if (k2 === void 0)
+        k2 = k;
+      o[k2] = m[k];
+    });
+    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+      Object.defineProperty(o, "default", { enumerable: true, value: v });
+    } : function(o, v) {
+      o["default"] = v;
+    });
+    var __importStar = exports2 && exports2.__importStar || function(mod) {
+      if (mod && mod.__esModule)
+        return mod;
+      var result = {};
+      if (mod != null) {
+        for (var k in mod)
+          if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k))
+            __createBinding(result, mod, k);
+      }
+      __setModuleDefault(result, mod);
+      return result;
+    };
+    var __exportStar = exports2 && exports2.__exportStar || function(m, exports3) {
+      for (var p in m)
+        if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports3, p))
+          __createBinding(exports3, m, p);
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.sync = exports2.isexe = exports2.posix = exports2.win32 = void 0;
+    var posix2 = __importStar(require_posix());
+    exports2.posix = posix2;
+    var win32 = __importStar(require_win32());
+    exports2.win32 = win32;
+    __exportStar(require_options(), exports2);
+    var platform = process.env._ISEXE_TEST_PLATFORM_ || process.platform;
+    var impl = platform === "win32" ? win32 : posix2;
+    exports2.isexe = impl.isexe;
+    exports2.sync = impl.sync;
+  }
+});
+
+// node_modules/.pnpm/which@4.0.0/node_modules/which/lib/index.js
+var require_lib2 = __commonJS({
+  "node_modules/.pnpm/which@4.0.0/node_modules/which/lib/index.js"(exports2, module2) {
+    var { isexe, sync: isexeSync } = require_cjs();
+    var { join: join2, delimiter, sep, posix: posix2 } = require("path");
+    var isWindows = process.platform === "win32";
+    var rSlash = new RegExp(`[${posix2.sep}${sep === posix2.sep ? "" : sep}]`.replace(/(\\)/g, "\\$1"));
+    var rRel = new RegExp(`^\\.${rSlash.source}`);
+    var getNotFoundError = (cmd) => Object.assign(new Error(`not found: ${cmd}`), { code: "ENOENT" });
+    var getPathInfo = (cmd, {
+      path: optPath = process.env.PATH,
+      pathExt: optPathExt = process.env.PATHEXT,
+      delimiter: optDelimiter = delimiter
+    }) => {
+      const pathEnv = cmd.match(rSlash) ? [""] : [
+        // windows always checks the cwd first
+        ...isWindows ? [process.cwd()] : [],
+        ...(optPath || /* istanbul ignore next: very unusual */
+        "").split(optDelimiter)
+      ];
+      if (isWindows) {
+        const pathExtExe = optPathExt || [".EXE", ".CMD", ".BAT", ".COM"].join(optDelimiter);
+        const pathExt = pathExtExe.split(optDelimiter).flatMap((item) => [item, item.toLowerCase()]);
+        if (cmd.includes(".") && pathExt[0] !== "") {
+          pathExt.unshift("");
+        }
+        return { pathEnv, pathExt, pathExtExe };
+      }
+      return { pathEnv, pathExt: [""] };
+    };
+    var getPathPart = (raw, cmd) => {
+      const pathPart = /^".*"$/.test(raw) ? raw.slice(1, -1) : raw;
+      const prefix = !pathPart && rRel.test(cmd) ? cmd.slice(0, 2) : "";
+      return prefix + join2(pathPart, cmd);
+    };
+    var which2 = async (cmd, opt = {}) => {
+      const { pathEnv, pathExt, pathExtExe } = getPathInfo(cmd, opt);
+      const found = [];
+      for (const envPart of pathEnv) {
+        const p = getPathPart(envPart, cmd);
+        for (const ext of pathExt) {
+          const withExt = p + ext;
+          const is = await isexe(withExt, { pathExt: pathExtExe, ignoreErrors: true });
+          if (is) {
+            if (!opt.all) {
+              return withExt;
+            }
+            found.push(withExt);
+          }
+        }
+      }
+      if (opt.all && found.length) {
+        return found;
+      }
+      if (opt.nothrow) {
+        return null;
+      }
+      throw getNotFoundError(cmd);
+    };
+    var whichSync = (cmd, opt = {}) => {
+      const { pathEnv, pathExt, pathExtExe } = getPathInfo(cmd, opt);
+      const found = [];
+      for (const pathEnvPart of pathEnv) {
+        const p = getPathPart(pathEnvPart, cmd);
+        for (const ext of pathExt) {
+          const withExt = p + ext;
+          const is = isexeSync(withExt, { pathExt: pathExtExe, ignoreErrors: true });
+          if (is) {
+            if (!opt.all) {
+              return withExt;
+            }
+            found.push(withExt);
+          }
+        }
+      }
+      if (opt.all && found.length) {
+        return found;
+      }
+      if (opt.nothrow) {
+        return null;
+      }
+      throw getNotFoundError(cmd);
+    };
+    module2.exports = which2;
+    which2.sync = whichSync;
+  }
+});
+
 // src/main.ts
 var import_node_assert = __toESM(require("node:assert"));
-var cp = __toESM(require("node:child_process"));
+var cp2 = __toESM(require("node:child_process"));
 var fs = __toESM(require("node:fs"));
 var path2 = __toESM(require("node:path"));
 var import_node_util = require("node:util");
@@ -8794,12 +9049,14 @@ var import_semver3 = __toESM(require_semver());
 var import_shell_quote2 = __toESM(require_shell_quote());
 
 // src/helpers.ts
+var cp = __toESM(require("node:child_process"));
 var path = __toESM(require("node:path"));
 var core = __toESM(require_core());
 var httpClient = __toESM(require_lib());
 var tc = __toESM(require_tool_cache());
 var import_semver2 = __toESM(require_semver());
 var import_shell_quote = __toESM(require_shell_quote());
+var import_which = __toESM(require_lib2());
 
 // package.json
 var version2 = "2.2.1";
@@ -9925,11 +10182,23 @@ var flagsWithoutCommentingSupport = /* @__PURE__ */ new Set([
 ]);
 async function getArgs(execPath) {
   const pyrightInfo = await getPyrightInfo();
-  const pyrightPath = await downloadPyright(pyrightInfo);
-  const command = execPath;
+  let pyrightPath;
+  let command;
+  switch (pyrightInfo.kind) {
+    case "npm":
+      pyrightPath = await downloadPyright(pyrightInfo);
+      command = execPath;
+      break;
+    case "path":
+      command = pyrightInfo.command;
+      break;
+  }
   const pyrightVersion = new import_semver2.default(pyrightInfo.version);
   const useDashedFlags = pyrightVersion.compare("1.1.309") === -1;
-  const args = [path.join(pyrightPath, "package", "index.js")];
+  const args = [];
+  if (pyrightPath) {
+    args.push(path.join(pyrightPath, "package", "index.js"));
+  }
   const workingDirectory = core.getInput("working-directory");
   const createStub = core.getInput("create-stub");
   if (createStub) {
@@ -10065,6 +10334,19 @@ async function downloadPyright(info3) {
 }
 async function getPyrightInfo() {
   const version3 = await getPyrightVersion();
+  if (version3 === "PATH") {
+    const command = import_which.default.sync("pyright");
+    const versionOut = cp.execFileSync(command, ["--version"], { encoding: "utf8" });
+    const versionRaw = versionOut.trim().split(/\s+/).at(-1);
+    if (!versionRaw)
+      throw new Error(`Failed to parse pyright version from ${versionOut}`);
+    const version4 = new import_semver2.default(versionRaw).format();
+    return {
+      kind: "path",
+      version: version4,
+      command
+    };
+  }
   const client = new httpClient.HttpClient();
   const url = `https://registry.npmjs.org/pyright/${version3}`;
   const resp = await client.get(url);
@@ -10082,6 +10364,9 @@ async function getPyrightInfo() {
 async function getPyrightVersion() {
   const versionSpec = core.getInput("version");
   if (versionSpec) {
+    if (versionSpec.toUpperCase() === "PATH") {
+      return "PATH";
+    }
     return new import_semver2.default(versionSpec).format();
   }
   const pylanceVersion = core.getInput("pylance-version");
@@ -10126,7 +10411,7 @@ async function main() {
     }
     if (annotate.size === 0) {
       printInfo(pyrightVersion, node, process.cwd(), command, args);
-      const { status: status2 } = cp.spawnSync(command, args, {
+      const { status: status2 } = cp2.spawnSync(command, args, {
         stdio: ["ignore", "inherit", "inherit"]
       });
       if (status2 !== 0) {
@@ -10139,7 +10424,7 @@ async function main() {
       updatedArgs.push("--outputjson");
     }
     printInfo(pyrightVersion, node, process.cwd(), command, updatedArgs);
-    const { status, stdout } = cp.spawnSync(command, updatedArgs, {
+    const { status, stdout } = cp2.spawnSync(command, updatedArgs, {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "inherit"],
       maxBuffer: 100 * 1024 * 1024

--- a/dist/index.js
+++ b/dist/index.js
@@ -10339,7 +10339,7 @@ async function getPyrightInfo() {
     const versionOut = cp.execFileSync(command, ["--version"], { encoding: "utf8" });
     const versionRaw = versionOut.trim().split(/\s+/).at(-1);
     if (!versionRaw)
-      throw new Error(`Failed to parse pyright version from ${versionOut}`);
+      throw new Error(`Failed to parse pyright version from ${JSON.stringify(versionOut)}`);
     const version4 = new import_semver2.default(versionRaw).format();
     return {
       kind: "path",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
         "@iarna/toml": "^2.2.5",
         "jsonc-parser": "^3.2.1",
         "semver": "^7.6.0",
-        "shell-quote": "^1.8.1"
+        "shell-quote": "^1.8.1",
+        "which": "^4.0.0"
     },
     "devDependencies": {
         "@tsconfig/node20": "^20.1.4",
@@ -29,6 +30,7 @@
         "@types/node": "^20.12.7",
         "@types/semver": "^7.5.8",
         "@types/shell-quote": "^1.7.5",
+        "@types/which": "^3.0.3",
         "@typescript-eslint/eslint-plugin": "^7.6.0",
         "@typescript-eslint/parser": "^7.6.0",
         "@vitest/coverage-v8": "^1.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ dependencies:
   shell-quote:
     specifier: ^1.8.1
     version: 1.8.1
+  which:
+    specifier: ^4.0.0
+    version: 4.0.0
 
 devDependencies:
   '@tsconfig/node20':
@@ -46,6 +49,9 @@ devDependencies:
   '@types/shell-quote':
     specifier: ^1.7.5
     version: 1.7.5
+  '@types/which':
+    specifier: ^3.0.3
+    version: 3.0.3
   '@typescript-eslint/eslint-plugin':
     specifier: ^7.6.0
     version: 7.6.0(@typescript-eslint/parser@7.6.0)(eslint@8.57.0)(typescript@5.4.4)
@@ -758,6 +764,10 @@ packages:
 
   /@types/shell-quote@1.7.5:
     resolution: {integrity: sha512-+UE8GAGRPbJVQDdxi16dgadcBfQ+KG2vgZhV1+3A1XmHbmwcdwhCUwIdy+d3pAGrbvgRoVSjeI9vOWyq376Yzw==}
+    dev: true
+
+  /@types/which@3.0.3:
+    resolution: {integrity: sha512-2C1+XoY0huExTbs8MQv1DuS5FS86+SEjdM9F/+GS61gg5Hqbtj8ZiDSx8MfWcyei907fIPbfPGCOrNUTnVHY1g==}
     dev: true
 
   /@typescript-eslint/eslint-plugin@7.6.0(@typescript-eslint/parser@7.6.0)(eslint@8.57.0)(typescript@5.4.4):
@@ -1741,6 +1751,11 @@ packages:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
     dev: true
 
+  /isexe@3.1.1:
+    resolution: {integrity: sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==}
+    engines: {node: '>=16'}
+    dev: false
+
   /istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
@@ -2721,6 +2736,14 @@ packages:
     dependencies:
       isexe: 2.0.0
     dev: true
+
+  /which@4.0.0:
+    resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
+    engines: {node: ^16.13.0 || >=18.0.0}
+    hasBin: true
+    dependencies:
+      isexe: 3.1.1
+    dev: false
 
   /why-is-node-running@2.2.2:
     resolution: {integrity: sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==}

--- a/src/__snapshots__/helpers.test.ts.snap
+++ b/src/__snapshots__/helpers.test.ts.snap
@@ -3889,6 +3889,120 @@ exports[`getArgs > valid version > version path > which.sync 1`] = `
 ]
 `;
 
+exports[`getArgs > valid version > version path bad version > core.getInput 1`] = `
+[
+  [
+    "version",
+  ],
+]
+`;
+
+exports[`getArgs > valid version > version path bad version > cp.execFileSync 1`] = `
+[
+  [
+    "/path/to/which/pyright",
+    [
+      "--version",
+    ],
+    {
+      "encoding": "utf8",
+    },
+  ],
+]
+`;
+
+exports[`getArgs > valid version > version path bad version > tc.cacheDir 1`] = `[]`;
+
+exports[`getArgs > valid version > version path bad version > tc.downloadTool 1`] = `[]`;
+
+exports[`getArgs > valid version > version path bad version > tc.extractTar 1`] = `[]`;
+
+exports[`getArgs > valid version > version path bad version > tc.find 1`] = `[]`;
+
+exports[`getArgs > valid version > version path bad version > which.sync 1`] = `
+[
+  [
+    "pyright",
+  ],
+]
+`;
+
+exports[`getArgs > valid version > version path bad version 2 > core.getInput 1`] = `
+[
+  [
+    "version",
+  ],
+]
+`;
+
+exports[`getArgs > valid version > version path bad version 2 > cp.execFileSync 1`] = `
+[
+  [
+    "/path/to/which/pyright",
+    [
+      "--version",
+    ],
+    {
+      "encoding": "utf8",
+    },
+  ],
+]
+`;
+
+exports[`getArgs > valid version > version path bad version 2 > tc.cacheDir 1`] = `[]`;
+
+exports[`getArgs > valid version > version path bad version 2 > tc.downloadTool 1`] = `[]`;
+
+exports[`getArgs > valid version > version path bad version 2 > tc.extractTar 1`] = `[]`;
+
+exports[`getArgs > valid version > version path bad version 2 > tc.find 1`] = `[]`;
+
+exports[`getArgs > valid version > version path bad version 2 > which.sync 1`] = `
+[
+  [
+    "pyright",
+  ],
+]
+`;
+
+exports[`getArgs > valid version > version path bad version 3 > core.getInput 1`] = `
+[
+  [
+    "version",
+  ],
+]
+`;
+
+exports[`getArgs > valid version > version path bad version 3 > cp.execFileSync 1`] = `
+[
+  [
+    "/path/to/which/pyright",
+    [
+      "--version",
+    ],
+    {
+      "encoding": "utf8",
+    },
+  ],
+]
+`;
+
+exports[`getArgs > valid version > version path bad version 3 > tc.cacheDir 1`] = `[]`;
+
+exports[`getArgs > valid version > version path bad version 3 > tc.downloadTool 1`] = `[]`;
+
+exports[`getArgs > valid version > version path bad version 3 > tc.extractTar 1`] = `[]`;
+
+exports[`getArgs > valid version > version path bad version 3 > tc.find 1`] = `[]`;
+
+exports[`getArgs > valid version > version path bad version 3 > which.sync 1`] = `
+[
+  [
+    "pyright",
+  ],
+]
+`;
+
 exports[`getArgs > valid version > version path error executing > core.getInput 1`] = `
 [
   [

--- a/src/__snapshots__/helpers.test.ts.snap
+++ b/src/__snapshots__/helpers.test.ts.snap
@@ -126,6 +126,7 @@ exports[`getArgs > valid version > 1.1.308 dashes > result 1`] = `
     "--venv-path",
     "/path/to-venv",
   ],
+  "command": "<execPath>",
   "pyrightVersion": "1.1.308",
   "workingDirectory": "",
 }
@@ -247,6 +248,7 @@ exports[`getArgs > valid version > 1.1.309 dashes > result 1`] = `
     "--venvpath",
     "/path/to-venv",
   ],
+  "command": "<execPath>",
   "pyrightVersion": "1.1.309",
   "workingDirectory": "",
 }
@@ -368,6 +370,7 @@ exports[`getArgs > valid version > 1.1.310 dashes > result 1`] = `
     "--venvpath",
     "/path/to-venv",
   ],
+  "command": "<execPath>",
   "pyrightVersion": "1.1.310",
   "workingDirectory": "",
 }
@@ -488,6 +491,7 @@ exports[`getArgs > valid version > annotate "" > result 1`] = `
   "args": [
     "<TEMP_DIR>/rootDir/cached/pyright/package/index.js",
   ],
+  "command": "<execPath>",
   "pyrightVersion": "1.1.240",
   "workingDirectory": "",
 }
@@ -605,6 +609,7 @@ exports[`getArgs > valid version > annotate "False" > result 1`] = `
   "args": [
     "<TEMP_DIR>/rootDir/cached/pyright/package/index.js",
   ],
+  "command": "<execPath>",
   "pyrightVersion": "1.1.240",
   "workingDirectory": "",
 }
@@ -725,6 +730,7 @@ exports[`getArgs > valid version > annotate "True" > result 1`] = `
   "args": [
     "<TEMP_DIR>/rootDir/cached/pyright/package/index.js",
   ],
+  "command": "<execPath>",
   "pyrightVersion": "1.1.240",
   "workingDirectory": "",
 }
@@ -845,6 +851,7 @@ exports[`getArgs > valid version > annotate "all" > result 1`] = `
   "args": [
     "<TEMP_DIR>/rootDir/cached/pyright/package/index.js",
   ],
+  "command": "<execPath>",
   "pyrightVersion": "1.1.240",
   "workingDirectory": "",
 }
@@ -964,6 +971,7 @@ exports[`getArgs > valid version > annotate "errors" > result 1`] = `
   "args": [
     "<TEMP_DIR>/rootDir/cached/pyright/package/index.js",
   ],
+  "command": "<execPath>",
   "pyrightVersion": "1.1.240",
   "workingDirectory": "",
 }
@@ -1084,6 +1092,7 @@ exports[`getArgs > valid version > annotate "errors, warnings" > result 1`] = `
   "args": [
     "<TEMP_DIR>/rootDir/cached/pyright/package/index.js",
   ],
+  "command": "<execPath>",
   "pyrightVersion": "1.1.240",
   "workingDirectory": "",
 }
@@ -1201,6 +1210,7 @@ exports[`getArgs > valid version > annotate "false" > result 1`] = `
   "args": [
     "<TEMP_DIR>/rootDir/cached/pyright/package/index.js",
   ],
+  "command": "<execPath>",
   "pyrightVersion": "1.1.240",
   "workingDirectory": "",
 }
@@ -1318,6 +1328,7 @@ exports[`getArgs > valid version > annotate "none" > result 1`] = `
   "args": [
     "<TEMP_DIR>/rootDir/cached/pyright/package/index.js",
   ],
+  "command": "<execPath>",
   "pyrightVersion": "1.1.240",
   "workingDirectory": "",
 }
@@ -1438,6 +1449,7 @@ exports[`getArgs > valid version > annotate "true" > result 1`] = `
   "args": [
     "<TEMP_DIR>/rootDir/cached/pyright/package/index.js",
   ],
+  "command": "<execPath>",
   "pyrightVersion": "1.1.240",
   "workingDirectory": "",
 }
@@ -1557,6 +1569,7 @@ exports[`getArgs > valid version > annotate "warnings" > result 1`] = `
   "args": [
     "<TEMP_DIR>/rootDir/cached/pyright/package/index.js",
   ],
+  "command": "<execPath>",
   "pyrightVersion": "1.1.240",
   "workingDirectory": "",
 }
@@ -1677,6 +1690,7 @@ exports[`getArgs > valid version > annotate "warnings,errors" > result 1`] = `
   "args": [
     "<TEMP_DIR>/rootDir/cached/pyright/package/index.js",
   ],
+  "command": "<execPath>",
   "pyrightVersion": "1.1.240",
   "workingDirectory": "",
 }
@@ -2003,6 +2017,7 @@ exports[`getArgs > valid version > cached > result 1`] = `
   "args": [
     "<TEMP_DIR>/rootDir/cached/pyright/package/index.js",
   ],
+  "command": "<execPath>",
   "pyrightVersion": "1.1.240",
   "workingDirectory": "",
 }
@@ -2102,6 +2117,7 @@ exports[`getArgs > valid version > createstub > result 1`] = `
     "--createstub",
     "pygame",
   ],
+  "command": "<execPath>",
   "pyrightVersion": "1.1.240",
   "workingDirectory": "",
 }
@@ -2221,6 +2237,7 @@ exports[`getArgs > valid version > dependencies > result 1`] = `
     "--dependencies",
     "TRUE",
   ],
+  "command": "<execPath>",
   "pyrightVersion": "1.1.240",
   "workingDirectory": "",
 }
@@ -2444,6 +2461,7 @@ exports[`getArgs > valid version > extra-args quotes > result 1`] = `
     "--bar",
     "--baz=quoted value",
   ],
+  "command": "<execPath>",
   "pyrightVersion": "1.1.240",
   "workingDirectory": "",
 }
@@ -2583,6 +2601,7 @@ exports[`getArgs > valid version > many options > result 1`] = `
     "--bar",
     "--baz",
   ],
+  "command": "<execPath>",
   "pyrightVersion": "1.1.240",
   "workingDirectory": "/path/to/project",
 }
@@ -2700,6 +2719,7 @@ exports[`getArgs > valid version > no comments > result 1`] = `
   "args": [
     "<TEMP_DIR>/rootDir/cached/pyright/package/index.js",
   ],
+  "command": "<execPath>",
   "pyrightVersion": "1.1.240",
   "workingDirectory": "",
 }
@@ -2820,6 +2840,7 @@ exports[`getArgs > valid version > pylance-version > result 1`] = `
   "args": [
     "<TEMP_DIR>/rootDir/cached/pyright/package/index.js",
   ],
+  "command": "<execPath>",
   "pyrightVersion": "9.9.999",
   "workingDirectory": "",
 }
@@ -2960,6 +2981,7 @@ exports[`getArgs > valid version > skip-unannotated > result 1`] = `
     "<TEMP_DIR>/rootDir/cached/pyright/package/index.js",
     "--skipunannotated",
   ],
+  "command": "<execPath>",
   "pyrightVersion": "1.1.240",
   "workingDirectory": "",
 }
@@ -3078,6 +3100,7 @@ exports[`getArgs > valid version > stats > result 1`] = `
     "<TEMP_DIR>/rootDir/cached/pyright/package/index.js",
     "--stats",
   ],
+  "command": "<execPath>",
   "pyrightVersion": "1.1.240",
   "workingDirectory": "",
 }
@@ -3199,6 +3222,7 @@ exports[`getArgs > valid version > verbose > result 1`] = `
     "<TEMP_DIR>/rootDir/cached/pyright/package/index.js",
     "--lib",
   ],
+  "command": "<execPath>",
   "pyrightVersion": "1.1.240",
   "workingDirectory": "",
 }
@@ -3317,6 +3341,7 @@ exports[`getArgs > valid version > verbose flag > result 1`] = `
     "<TEMP_DIR>/rootDir/cached/pyright/package/index.js",
     "--verbose",
   ],
+  "command": "<execPath>",
   "pyrightVersion": "1.1.240",
   "workingDirectory": "",
 }
@@ -3437,6 +3462,7 @@ exports[`getArgs > valid version > verifytypes > result 1`] = `
     "--verifytypes",
     "some.package",
   ],
+  "command": "<execPath>",
   "pyrightVersion": "1.1.240",
   "workingDirectory": "",
 }
@@ -3555,6 +3581,7 @@ exports[`getArgs > valid version > verifytypes flag > result 1`] = `
     "<TEMP_DIR>/rootDir/cached/pyright/package/index.js",
     "--verifytypes",
   ],
+  "command": "<execPath>",
   "pyrightVersion": "1.1.240",
   "workingDirectory": "",
 }
@@ -3688,6 +3715,7 @@ exports[`getArgs > valid version > version takes precedence over pylance-version
   "args": [
     "<TEMP_DIR>/rootDir/cached/pyright/package/index.js",
   ],
+  "command": "<execPath>",
   "pyrightVersion": "1.1.310",
   "workingDirectory": "",
 }

--- a/src/__snapshots__/helpers.test.ts.snap
+++ b/src/__snapshots__/helpers.test.ts.snap
@@ -2,6 +2,8 @@
 
 exports[`getActionVersion > core.getInput 1`] = `[]`;
 
+exports[`getActionVersion > cp.execFileSync 1`] = `[]`;
+
 exports[`getActionVersion > tc.cacheDir 1`] = `[]`;
 
 exports[`getActionVersion > tc.downloadTool 1`] = `[]`;
@@ -9,6 +11,8 @@ exports[`getActionVersion > tc.downloadTool 1`] = `[]`;
 exports[`getActionVersion > tc.extractTar 1`] = `[]`;
 
 exports[`getActionVersion > tc.find 1`] = `[]`;
+
+exports[`getActionVersion > which.sync 1`] = `[]`;
 
 exports[`getArgs > bad pylance-version > core.getInput 1`] = `
 [
@@ -21,6 +25,8 @@ exports[`getArgs > bad pylance-version > core.getInput 1`] = `
 ]
 `;
 
+exports[`getArgs > bad pylance-version > cp.execFileSync 1`] = `[]`;
+
 exports[`getArgs > bad pylance-version > tc.cacheDir 1`] = `[]`;
 
 exports[`getArgs > bad pylance-version > tc.downloadTool 1`] = `[]`;
@@ -28,6 +34,8 @@ exports[`getArgs > bad pylance-version > tc.downloadTool 1`] = `[]`;
 exports[`getArgs > bad pylance-version > tc.extractTar 1`] = `[]`;
 
 exports[`getArgs > bad pylance-version > tc.find 1`] = `[]`;
+
+exports[`getArgs > bad pylance-version > which.sync 1`] = `[]`;
 
 exports[`getArgs > bad version > core.getInput 1`] = `
 [
@@ -37,6 +45,8 @@ exports[`getArgs > bad version > core.getInput 1`] = `
 ]
 `;
 
+exports[`getArgs > bad version > cp.execFileSync 1`] = `[]`;
+
 exports[`getArgs > bad version > tc.cacheDir 1`] = `[]`;
 
 exports[`getArgs > bad version > tc.downloadTool 1`] = `[]`;
@@ -44,6 +54,8 @@ exports[`getArgs > bad version > tc.downloadTool 1`] = `[]`;
 exports[`getArgs > bad version > tc.extractTar 1`] = `[]`;
 
 exports[`getArgs > bad version > tc.find 1`] = `[]`;
+
+exports[`getArgs > bad version > which.sync 1`] = `[]`;
 
 exports[`getArgs > valid version > 1.1.308 dashes > core.getInput 1`] = `
 [
@@ -113,6 +125,8 @@ exports[`getArgs > valid version > 1.1.308 dashes > core.getInput 1`] = `
 ]
 `;
 
+exports[`getArgs > valid version > 1.1.308 dashes > cp.execFileSync 1`] = `[]`;
+
 exports[`getArgs > valid version > 1.1.308 dashes > result 1`] = `
 {
   "annotate": Set {
@@ -166,6 +180,8 @@ exports[`getArgs > valid version > 1.1.308 dashes > tc.find 1`] = `
   ],
 ]
 `;
+
+exports[`getArgs > valid version > 1.1.308 dashes > which.sync 1`] = `[]`;
 
 exports[`getArgs > valid version > 1.1.309 dashes > core.getInput 1`] = `
 [
@@ -235,6 +251,8 @@ exports[`getArgs > valid version > 1.1.309 dashes > core.getInput 1`] = `
 ]
 `;
 
+exports[`getArgs > valid version > 1.1.309 dashes > cp.execFileSync 1`] = `[]`;
+
 exports[`getArgs > valid version > 1.1.309 dashes > result 1`] = `
 {
   "annotate": Set {
@@ -288,6 +306,8 @@ exports[`getArgs > valid version > 1.1.309 dashes > tc.find 1`] = `
   ],
 ]
 `;
+
+exports[`getArgs > valid version > 1.1.309 dashes > which.sync 1`] = `[]`;
 
 exports[`getArgs > valid version > 1.1.310 dashes > core.getInput 1`] = `
 [
@@ -357,6 +377,8 @@ exports[`getArgs > valid version > 1.1.310 dashes > core.getInput 1`] = `
 ]
 `;
 
+exports[`getArgs > valid version > 1.1.310 dashes > cp.execFileSync 1`] = `[]`;
+
 exports[`getArgs > valid version > 1.1.310 dashes > result 1`] = `
 {
   "annotate": Set {
@@ -410,6 +432,8 @@ exports[`getArgs > valid version > 1.1.310 dashes > tc.find 1`] = `
   ],
 ]
 `;
+
+exports[`getArgs > valid version > 1.1.310 dashes > which.sync 1`] = `[]`;
 
 exports[`getArgs > valid version > annotate "" > core.getInput 1`] = `
 [
@@ -482,6 +506,8 @@ exports[`getArgs > valid version > annotate "" > core.getInput 1`] = `
 ]
 `;
 
+exports[`getArgs > valid version > annotate "" > cp.execFileSync 1`] = `[]`;
+
 exports[`getArgs > valid version > annotate "" > result 1`] = `
 {
   "annotate": Set {
@@ -531,6 +557,8 @@ exports[`getArgs > valid version > annotate "" > tc.find 1`] = `
   ],
 ]
 `;
+
+exports[`getArgs > valid version > annotate "" > which.sync 1`] = `[]`;
 
 exports[`getArgs > valid version > annotate "False" > core.getInput 1`] = `
 [
@@ -603,6 +631,8 @@ exports[`getArgs > valid version > annotate "False" > core.getInput 1`] = `
 ]
 `;
 
+exports[`getArgs > valid version > annotate "False" > cp.execFileSync 1`] = `[]`;
+
 exports[`getArgs > valid version > annotate "False" > result 1`] = `
 {
   "annotate": Set {},
@@ -649,6 +679,8 @@ exports[`getArgs > valid version > annotate "False" > tc.find 1`] = `
   ],
 ]
 `;
+
+exports[`getArgs > valid version > annotate "False" > which.sync 1`] = `[]`;
 
 exports[`getArgs > valid version > annotate "True" > core.getInput 1`] = `
 [
@@ -721,6 +753,8 @@ exports[`getArgs > valid version > annotate "True" > core.getInput 1`] = `
 ]
 `;
 
+exports[`getArgs > valid version > annotate "True" > cp.execFileSync 1`] = `[]`;
+
 exports[`getArgs > valid version > annotate "True" > result 1`] = `
 {
   "annotate": Set {
@@ -770,6 +804,8 @@ exports[`getArgs > valid version > annotate "True" > tc.find 1`] = `
   ],
 ]
 `;
+
+exports[`getArgs > valid version > annotate "True" > which.sync 1`] = `[]`;
 
 exports[`getArgs > valid version > annotate "all" > core.getInput 1`] = `
 [
@@ -842,6 +878,8 @@ exports[`getArgs > valid version > annotate "all" > core.getInput 1`] = `
 ]
 `;
 
+exports[`getArgs > valid version > annotate "all" > cp.execFileSync 1`] = `[]`;
+
 exports[`getArgs > valid version > annotate "all" > result 1`] = `
 {
   "annotate": Set {
@@ -891,6 +929,8 @@ exports[`getArgs > valid version > annotate "all" > tc.find 1`] = `
   ],
 ]
 `;
+
+exports[`getArgs > valid version > annotate "all" > which.sync 1`] = `[]`;
 
 exports[`getArgs > valid version > annotate "errors" > core.getInput 1`] = `
 [
@@ -963,6 +1003,8 @@ exports[`getArgs > valid version > annotate "errors" > core.getInput 1`] = `
 ]
 `;
 
+exports[`getArgs > valid version > annotate "errors" > cp.execFileSync 1`] = `[]`;
+
 exports[`getArgs > valid version > annotate "errors" > result 1`] = `
 {
   "annotate": Set {
@@ -1011,6 +1053,8 @@ exports[`getArgs > valid version > annotate "errors" > tc.find 1`] = `
   ],
 ]
 `;
+
+exports[`getArgs > valid version > annotate "errors" > which.sync 1`] = `[]`;
 
 exports[`getArgs > valid version > annotate "errors, warnings" > core.getInput 1`] = `
 [
@@ -1083,6 +1127,8 @@ exports[`getArgs > valid version > annotate "errors, warnings" > core.getInput 1
 ]
 `;
 
+exports[`getArgs > valid version > annotate "errors, warnings" > cp.execFileSync 1`] = `[]`;
+
 exports[`getArgs > valid version > annotate "errors, warnings" > result 1`] = `
 {
   "annotate": Set {
@@ -1132,6 +1178,8 @@ exports[`getArgs > valid version > annotate "errors, warnings" > tc.find 1`] = `
   ],
 ]
 `;
+
+exports[`getArgs > valid version > annotate "errors, warnings" > which.sync 1`] = `[]`;
 
 exports[`getArgs > valid version > annotate "false" > core.getInput 1`] = `
 [
@@ -1204,6 +1252,8 @@ exports[`getArgs > valid version > annotate "false" > core.getInput 1`] = `
 ]
 `;
 
+exports[`getArgs > valid version > annotate "false" > cp.execFileSync 1`] = `[]`;
+
 exports[`getArgs > valid version > annotate "false" > result 1`] = `
 {
   "annotate": Set {},
@@ -1250,6 +1300,8 @@ exports[`getArgs > valid version > annotate "false" > tc.find 1`] = `
   ],
 ]
 `;
+
+exports[`getArgs > valid version > annotate "false" > which.sync 1`] = `[]`;
 
 exports[`getArgs > valid version > annotate "none" > core.getInput 1`] = `
 [
@@ -1322,6 +1374,8 @@ exports[`getArgs > valid version > annotate "none" > core.getInput 1`] = `
 ]
 `;
 
+exports[`getArgs > valid version > annotate "none" > cp.execFileSync 1`] = `[]`;
+
 exports[`getArgs > valid version > annotate "none" > result 1`] = `
 {
   "annotate": Set {},
@@ -1368,6 +1422,8 @@ exports[`getArgs > valid version > annotate "none" > tc.find 1`] = `
   ],
 ]
 `;
+
+exports[`getArgs > valid version > annotate "none" > which.sync 1`] = `[]`;
 
 exports[`getArgs > valid version > annotate "true" > core.getInput 1`] = `
 [
@@ -1440,6 +1496,8 @@ exports[`getArgs > valid version > annotate "true" > core.getInput 1`] = `
 ]
 `;
 
+exports[`getArgs > valid version > annotate "true" > cp.execFileSync 1`] = `[]`;
+
 exports[`getArgs > valid version > annotate "true" > result 1`] = `
 {
   "annotate": Set {
@@ -1489,6 +1547,8 @@ exports[`getArgs > valid version > annotate "true" > tc.find 1`] = `
   ],
 ]
 `;
+
+exports[`getArgs > valid version > annotate "true" > which.sync 1`] = `[]`;
 
 exports[`getArgs > valid version > annotate "warnings" > core.getInput 1`] = `
 [
@@ -1561,6 +1621,8 @@ exports[`getArgs > valid version > annotate "warnings" > core.getInput 1`] = `
 ]
 `;
 
+exports[`getArgs > valid version > annotate "warnings" > cp.execFileSync 1`] = `[]`;
+
 exports[`getArgs > valid version > annotate "warnings" > result 1`] = `
 {
   "annotate": Set {
@@ -1609,6 +1671,8 @@ exports[`getArgs > valid version > annotate "warnings" > tc.find 1`] = `
   ],
 ]
 `;
+
+exports[`getArgs > valid version > annotate "warnings" > which.sync 1`] = `[]`;
 
 exports[`getArgs > valid version > annotate "warnings,errors" > core.getInput 1`] = `
 [
@@ -1681,6 +1745,8 @@ exports[`getArgs > valid version > annotate "warnings,errors" > core.getInput 1`
 ]
 `;
 
+exports[`getArgs > valid version > annotate "warnings,errors" > cp.execFileSync 1`] = `[]`;
+
 exports[`getArgs > valid version > annotate "warnings,errors" > result 1`] = `
 {
   "annotate": Set {
@@ -1730,6 +1796,8 @@ exports[`getArgs > valid version > annotate "warnings,errors" > tc.find 1`] = `
   ],
 ]
 `;
+
+exports[`getArgs > valid version > annotate "warnings,errors" > which.sync 1`] = `[]`;
 
 exports[`getArgs > valid version > annotate invalid > core.getInput 1`] = `
 [
@@ -1799,6 +1867,8 @@ exports[`getArgs > valid version > annotate invalid > core.getInput 1`] = `
 ]
 `;
 
+exports[`getArgs > valid version > annotate invalid > cp.execFileSync 1`] = `[]`;
+
 exports[`getArgs > valid version > annotate invalid > tc.cacheDir 1`] = `
 [
   [
@@ -1833,6 +1903,8 @@ exports[`getArgs > valid version > annotate invalid > tc.find 1`] = `
   ],
 ]
 `;
+
+exports[`getArgs > valid version > annotate invalid > which.sync 1`] = `[]`;
 
 exports[`getArgs > valid version > annotate invalid comma > core.getInput 1`] = `
 [
@@ -1902,6 +1974,8 @@ exports[`getArgs > valid version > annotate invalid comma > core.getInput 1`] = 
 ]
 `;
 
+exports[`getArgs > valid version > annotate invalid comma > cp.execFileSync 1`] = `[]`;
+
 exports[`getArgs > valid version > annotate invalid comma > tc.cacheDir 1`] = `
 [
   [
@@ -1936,6 +2010,8 @@ exports[`getArgs > valid version > annotate invalid comma > tc.find 1`] = `
   ],
 ]
 `;
+
+exports[`getArgs > valid version > annotate invalid comma > which.sync 1`] = `[]`;
 
 exports[`getArgs > valid version > cached > core.getInput 1`] = `
 [
@@ -2008,6 +2084,8 @@ exports[`getArgs > valid version > cached > core.getInput 1`] = `
 ]
 `;
 
+exports[`getArgs > valid version > cached > cp.execFileSync 1`] = `[]`;
+
 exports[`getArgs > valid version > cached > result 1`] = `
 {
   "annotate": Set {
@@ -2037,6 +2115,8 @@ exports[`getArgs > valid version > cached > tc.find 1`] = `
   ],
 ]
 `;
+
+exports[`getArgs > valid version > cached > which.sync 1`] = `[]`;
 
 exports[`getArgs > valid version > createstub > core.getInput 1`] = `
 [
@@ -2109,6 +2189,8 @@ exports[`getArgs > valid version > createstub > core.getInput 1`] = `
 ]
 `;
 
+exports[`getArgs > valid version > createstub > cp.execFileSync 1`] = `[]`;
+
 exports[`getArgs > valid version > createstub > result 1`] = `
 {
   "annotate": Set {},
@@ -2157,6 +2239,8 @@ exports[`getArgs > valid version > createstub > tc.find 1`] = `
   ],
 ]
 `;
+
+exports[`getArgs > valid version > createstub > which.sync 1`] = `[]`;
 
 exports[`getArgs > valid version > dependencies > core.getInput 1`] = `
 [
@@ -2229,6 +2313,8 @@ exports[`getArgs > valid version > dependencies > core.getInput 1`] = `
 ]
 `;
 
+exports[`getArgs > valid version > dependencies > cp.execFileSync 1`] = `[]`;
+
 exports[`getArgs > valid version > dependencies > result 1`] = `
 {
   "annotate": Set {},
@@ -2277,6 +2363,8 @@ exports[`getArgs > valid version > dependencies > tc.find 1`] = `
   ],
 ]
 `;
+
+exports[`getArgs > valid version > dependencies > which.sync 1`] = `[]`;
 
 exports[`getArgs > valid version > extra-args malformed > core.getInput 1`] = `
 [
@@ -2343,6 +2431,8 @@ exports[`getArgs > valid version > extra-args malformed > core.getInput 1`] = `
 ]
 `;
 
+exports[`getArgs > valid version > extra-args malformed > cp.execFileSync 1`] = `[]`;
+
 exports[`getArgs > valid version > extra-args malformed > tc.cacheDir 1`] = `
 [
   [
@@ -2377,6 +2467,8 @@ exports[`getArgs > valid version > extra-args malformed > tc.find 1`] = `
   ],
 ]
 `;
+
+exports[`getArgs > valid version > extra-args malformed > which.sync 1`] = `[]`;
 
 exports[`getArgs > valid version > extra-args quotes > core.getInput 1`] = `
 [
@@ -2449,6 +2541,8 @@ exports[`getArgs > valid version > extra-args quotes > core.getInput 1`] = `
 ]
 `;
 
+exports[`getArgs > valid version > extra-args quotes > cp.execFileSync 1`] = `[]`;
+
 exports[`getArgs > valid version > extra-args quotes > result 1`] = `
 {
   "annotate": Set {
@@ -2501,6 +2595,8 @@ exports[`getArgs > valid version > extra-args quotes > tc.find 1`] = `
   ],
 ]
 `;
+
+exports[`getArgs > valid version > extra-args quotes > which.sync 1`] = `[]`;
 
 exports[`getArgs > valid version > many options > core.getInput 1`] = `
 [
@@ -2573,6 +2669,8 @@ exports[`getArgs > valid version > many options > core.getInput 1`] = `
 ]
 `;
 
+exports[`getArgs > valid version > many options > cp.execFileSync 1`] = `[]`;
+
 exports[`getArgs > valid version > many options > result 1`] = `
 {
   "annotate": Set {
@@ -2641,6 +2739,8 @@ exports[`getArgs > valid version > many options > tc.find 1`] = `
   ],
 ]
 `;
+
+exports[`getArgs > valid version > many options > which.sync 1`] = `[]`;
 
 exports[`getArgs > valid version > no comments > core.getInput 1`] = `
 [
@@ -2713,6 +2813,8 @@ exports[`getArgs > valid version > no comments > core.getInput 1`] = `
 ]
 `;
 
+exports[`getArgs > valid version > no comments > cp.execFileSync 1`] = `[]`;
+
 exports[`getArgs > valid version > no comments > result 1`] = `
 {
   "annotate": Set {},
@@ -2759,6 +2861,8 @@ exports[`getArgs > valid version > no comments > tc.find 1`] = `
   ],
 ]
 `;
+
+exports[`getArgs > valid version > no comments > which.sync 1`] = `[]`;
 
 exports[`getArgs > valid version > pylance-version > core.getInput 1`] = `
 [
@@ -2831,6 +2935,8 @@ exports[`getArgs > valid version > pylance-version > core.getInput 1`] = `
 ]
 `;
 
+exports[`getArgs > valid version > pylance-version > cp.execFileSync 1`] = `[]`;
+
 exports[`getArgs > valid version > pylance-version > result 1`] = `
 {
   "annotate": Set {
@@ -2881,6 +2987,8 @@ exports[`getArgs > valid version > pylance-version > tc.find 1`] = `
 ]
 `;
 
+exports[`getArgs > valid version > pylance-version > which.sync 1`] = `[]`;
+
 exports[`getArgs > valid version > pylance-version not found > core.getInput 1`] = `
 [
   [
@@ -2892,6 +3000,8 @@ exports[`getArgs > valid version > pylance-version not found > core.getInput 1`]
 ]
 `;
 
+exports[`getArgs > valid version > pylance-version not found > cp.execFileSync 1`] = `[]`;
+
 exports[`getArgs > valid version > pylance-version not found > tc.cacheDir 1`] = `[]`;
 
 exports[`getArgs > valid version > pylance-version not found > tc.downloadTool 1`] = `[]`;
@@ -2899,6 +3009,8 @@ exports[`getArgs > valid version > pylance-version not found > tc.downloadTool 1
 exports[`getArgs > valid version > pylance-version not found > tc.extractTar 1`] = `[]`;
 
 exports[`getArgs > valid version > pylance-version not found > tc.find 1`] = `[]`;
+
+exports[`getArgs > valid version > pylance-version not found > which.sync 1`] = `[]`;
 
 exports[`getArgs > valid version > skip-unannotated > core.getInput 1`] = `
 [
@@ -2971,6 +3083,8 @@ exports[`getArgs > valid version > skip-unannotated > core.getInput 1`] = `
 ]
 `;
 
+exports[`getArgs > valid version > skip-unannotated > cp.execFileSync 1`] = `[]`;
+
 exports[`getArgs > valid version > skip-unannotated > result 1`] = `
 {
   "annotate": Set {
@@ -3021,6 +3135,8 @@ exports[`getArgs > valid version > skip-unannotated > tc.find 1`] = `
   ],
 ]
 `;
+
+exports[`getArgs > valid version > skip-unannotated > which.sync 1`] = `[]`;
 
 exports[`getArgs > valid version > stats > core.getInput 1`] = `
 [
@@ -3093,6 +3209,8 @@ exports[`getArgs > valid version > stats > core.getInput 1`] = `
 ]
 `;
 
+exports[`getArgs > valid version > stats > cp.execFileSync 1`] = `[]`;
+
 exports[`getArgs > valid version > stats > result 1`] = `
 {
   "annotate": Set {},
@@ -3140,6 +3258,8 @@ exports[`getArgs > valid version > stats > tc.find 1`] = `
   ],
 ]
 `;
+
+exports[`getArgs > valid version > stats > which.sync 1`] = `[]`;
 
 exports[`getArgs > valid version > verbose > core.getInput 1`] = `
 [
@@ -3212,6 +3332,8 @@ exports[`getArgs > valid version > verbose > core.getInput 1`] = `
 ]
 `;
 
+exports[`getArgs > valid version > verbose > cp.execFileSync 1`] = `[]`;
+
 exports[`getArgs > valid version > verbose > result 1`] = `
 {
   "annotate": Set {
@@ -3262,6 +3384,8 @@ exports[`getArgs > valid version > verbose > tc.find 1`] = `
   ],
 ]
 `;
+
+exports[`getArgs > valid version > verbose > which.sync 1`] = `[]`;
 
 exports[`getArgs > valid version > verbose flag > core.getInput 1`] = `
 [
@@ -3334,6 +3458,8 @@ exports[`getArgs > valid version > verbose flag > core.getInput 1`] = `
 ]
 `;
 
+exports[`getArgs > valid version > verbose flag > cp.execFileSync 1`] = `[]`;
+
 exports[`getArgs > valid version > verbose flag > result 1`] = `
 {
   "annotate": Set {},
@@ -3381,6 +3507,8 @@ exports[`getArgs > valid version > verbose flag > tc.find 1`] = `
   ],
 ]
 `;
+
+exports[`getArgs > valid version > verbose flag > which.sync 1`] = `[]`;
 
 exports[`getArgs > valid version > verifytypes > core.getInput 1`] = `
 [
@@ -3453,6 +3581,8 @@ exports[`getArgs > valid version > verifytypes > core.getInput 1`] = `
 ]
 `;
 
+exports[`getArgs > valid version > verifytypes > cp.execFileSync 1`] = `[]`;
+
 exports[`getArgs > valid version > verifytypes > result 1`] = `
 {
   "annotate": Set {},
@@ -3502,6 +3632,8 @@ exports[`getArgs > valid version > verifytypes > tc.find 1`] = `
   ],
 ]
 `;
+
+exports[`getArgs > valid version > verifytypes > which.sync 1`] = `[]`;
 
 exports[`getArgs > valid version > verifytypes flag > core.getInput 1`] = `
 [
@@ -3574,6 +3706,8 @@ exports[`getArgs > valid version > verifytypes flag > core.getInput 1`] = `
 ]
 `;
 
+exports[`getArgs > valid version > verifytypes flag > cp.execFileSync 1`] = `[]`;
+
 exports[`getArgs > valid version > verifytypes flag > result 1`] = `
 {
   "annotate": Set {},
@@ -3622,6 +3756,8 @@ exports[`getArgs > valid version > verifytypes flag > tc.find 1`] = `
 ]
 `;
 
+exports[`getArgs > valid version > verifytypes flag > which.sync 1`] = `[]`;
+
 exports[`getArgs > valid version > version not found > core.getInput 1`] = `
 [
   [
@@ -3630,6 +3766,8 @@ exports[`getArgs > valid version > version not found > core.getInput 1`] = `
 ]
 `;
 
+exports[`getArgs > valid version > version not found > cp.execFileSync 1`] = `[]`;
+
 exports[`getArgs > valid version > version not found > tc.cacheDir 1`] = `[]`;
 
 exports[`getArgs > valid version > version not found > tc.downloadTool 1`] = `[]`;
@@ -3637,6 +3775,183 @@ exports[`getArgs > valid version > version not found > tc.downloadTool 1`] = `[]
 exports[`getArgs > valid version > version not found > tc.extractTar 1`] = `[]`;
 
 exports[`getArgs > valid version > version not found > tc.find 1`] = `[]`;
+
+exports[`getArgs > valid version > version not found > which.sync 1`] = `[]`;
+
+exports[`getArgs > valid version > version path > core.getInput 1`] = `
+[
+  [
+    "annotate",
+  ],
+  [
+    "create-stub",
+  ],
+  [
+    "dependencies",
+  ],
+  [
+    "extra-args",
+  ],
+  [
+    "ignore-external",
+  ],
+  [
+    "level",
+  ],
+  [
+    "lib",
+  ],
+  [
+    "no-comments",
+  ],
+  [
+    "project",
+  ],
+  [
+    "python-path",
+  ],
+  [
+    "python-platform",
+  ],
+  [
+    "python-version",
+  ],
+  [
+    "skip-unannotated",
+  ],
+  [
+    "stats",
+  ],
+  [
+    "typeshed-path",
+  ],
+  [
+    "venv-path",
+  ],
+  [
+    "verbose",
+  ],
+  [
+    "verify-types",
+  ],
+  [
+    "version",
+  ],
+  [
+    "warnings",
+  ],
+  [
+    "working-directory",
+  ],
+]
+`;
+
+exports[`getArgs > valid version > version path > cp.execFileSync 1`] = `
+[
+  [
+    "/path/to/which/pyright",
+    [
+      "--version",
+    ],
+    {
+      "encoding": "utf8",
+    },
+  ],
+]
+`;
+
+exports[`getArgs > valid version > version path > result 1`] = `
+{
+  "annotate": Set {
+    "error",
+    "warning",
+  },
+  "args": [],
+  "command": "/path/to/which/pyright",
+  "pyrightVersion": "1.1.240",
+  "workingDirectory": "",
+}
+`;
+
+exports[`getArgs > valid version > version path > tc.cacheDir 1`] = `[]`;
+
+exports[`getArgs > valid version > version path > tc.downloadTool 1`] = `[]`;
+
+exports[`getArgs > valid version > version path > tc.extractTar 1`] = `[]`;
+
+exports[`getArgs > valid version > version path > tc.find 1`] = `[]`;
+
+exports[`getArgs > valid version > version path > which.sync 1`] = `
+[
+  [
+    "pyright",
+  ],
+]
+`;
+
+exports[`getArgs > valid version > version path error executing > core.getInput 1`] = `
+[
+  [
+    "version",
+  ],
+]
+`;
+
+exports[`getArgs > valid version > version path error executing > cp.execFileSync 1`] = `
+[
+  [
+    "/path/to/which/pyright",
+    [
+      "--version",
+    ],
+    {
+      "encoding": "utf8",
+    },
+  ],
+]
+`;
+
+exports[`getArgs > valid version > version path error executing > tc.cacheDir 1`] = `[]`;
+
+exports[`getArgs > valid version > version path error executing > tc.downloadTool 1`] = `[]`;
+
+exports[`getArgs > valid version > version path error executing > tc.extractTar 1`] = `[]`;
+
+exports[`getArgs > valid version > version path error executing > tc.find 1`] = `[]`;
+
+exports[`getArgs > valid version > version path error executing > which.sync 1`] = `
+[
+  [
+    "pyright",
+  ],
+]
+`;
+
+exports[`getArgs > valid version > version path not found > core.getInput 1`] = `
+[
+  [
+    "version",
+  ],
+]
+`;
+
+exports[`getArgs > valid version > version path not found > cp.execFileSync 1`] = `[]`;
+
+exports[`getArgs > valid version > version path not found > tc.cacheDir 1`] = `[]`;
+
+exports[`getArgs > valid version > version path not found > tc.downloadTool 1`] = `[]`;
+
+exports[`getArgs > valid version > version path not found > tc.extractTar 1`] = `[]`;
+
+exports[`getArgs > valid version > version path not found > tc.find 1`] = `[]`;
+
+exports[`getArgs > valid version > version path not found > which.sync 1`] = `
+[
+  [
+    "pyright",
+  ],
+]
+`;
 
 exports[`getArgs > valid version > version takes precedence over pylance-version > core.getInput 1`] = `
 [
@@ -3706,6 +4021,8 @@ exports[`getArgs > valid version > version takes precedence over pylance-version
 ]
 `;
 
+exports[`getArgs > valid version > version takes precedence over pylance-version > cp.execFileSync 1`] = `[]`;
+
 exports[`getArgs > valid version > version takes precedence over pylance-version > result 1`] = `
 {
   "annotate": Set {
@@ -3756,7 +4073,11 @@ exports[`getArgs > valid version > version takes precedence over pylance-version
 ]
 `;
 
+exports[`getArgs > valid version > version takes precedence over pylance-version > which.sync 1`] = `[]`;
+
 exports[`getNodeInfo > core.getInput 1`] = `[]`;
+
+exports[`getNodeInfo > cp.execFileSync 1`] = `[]`;
 
 exports[`getNodeInfo > tc.cacheDir 1`] = `[]`;
 
@@ -3765,3 +4086,5 @@ exports[`getNodeInfo > tc.downloadTool 1`] = `[]`;
 exports[`getNodeInfo > tc.extractTar 1`] = `[]`;
 
 exports[`getNodeInfo > tc.find 1`] = `[]`;
+
+exports[`getNodeInfo > which.sync 1`] = `[]`;

--- a/src/helpers.test.ts
+++ b/src/helpers.test.ts
@@ -415,6 +415,30 @@ describe("getArgs", () => {
 
             await expect(getArgs(execPath)).rejects.toThrowError("error executing");
         });
+
+        test("version path bad version", async () => {
+            inputs.set("version", "path");
+            mockedWhich.sync.mockReturnValue("/path/to/which/pyright");
+            mockedCp.execFileSync.mockReturnValue(`oops`);
+
+            await expect(getArgs(execPath)).rejects.toThrowError("Invalid Version");
+        });
+
+        test("version path bad version 2", async () => {
+            inputs.set("version", "path");
+            mockedWhich.sync.mockReturnValue("/path/to/which/pyright");
+            mockedCp.execFileSync.mockReturnValue(`pyright xasdnodgu 38gnoan`);
+
+            await expect(getArgs(execPath)).rejects.toThrowError("Invalid Version");
+        });
+
+        test("version path bad version 3", async () => {
+            inputs.set("version", "path");
+            mockedWhich.sync.mockReturnValue("/path/to/which/pyright");
+            mockedCp.execFileSync.mockReturnValue(``);
+
+            await expect(getArgs(execPath)).rejects.toThrowError("Failed to parse");
+        });
     });
 });
 

--- a/src/helpers.test.ts
+++ b/src/helpers.test.ts
@@ -56,6 +56,8 @@ function getPylanceMetadata(pylanceVersion: string, pyrightVersion: string): Pyl
 const latestPyright = "1.1.240";
 
 describe("getArgs", () => {
+    const execPath = "<execPath>";
+
     test("bad version", async () => {
         mockedCore.getInput.mockImplementation((name, options) => {
             expect(options).toBeUndefined();
@@ -67,7 +69,7 @@ describe("getArgs", () => {
             }
         });
 
-        await expect(getArgs()).rejects.toThrowError("not a semver");
+        await expect(getArgs(execPath)).rejects.toThrowError("not a semver");
     });
 
     test("bad pylance-version", async () => {
@@ -81,7 +83,7 @@ describe("getArgs", () => {
             }
         });
 
-        await expect(getArgs()).rejects.toThrowError("not a semver");
+        await expect(getArgs(execPath)).rejects.toThrowError("not a semver");
     });
 
     describe("valid version", () => {
@@ -172,7 +174,7 @@ describe("getArgs", () => {
             inputs.set("extra-args", "--foo --bar --baz");
             inputs.set("level", "warning");
 
-            const result = await getArgs();
+            const result = await getArgs(execPath);
             expect(result).toMatchSnapshot("result");
 
             expect(mockedTc.downloadTool).toBeCalledWith(getNpmResponse(latestPyright).dist.tarball);
@@ -182,7 +184,7 @@ describe("getArgs", () => {
         test("no comments", async () => {
             inputs.set("no-comments", "true");
 
-            const result = await getArgs();
+            const result = await getArgs(execPath);
             expect(result).toMatchSnapshot("result");
         });
 
@@ -203,7 +205,7 @@ describe("getArgs", () => {
             async (input) => {
                 inputs.set("annotate", input);
 
-                const result = await getArgs();
+                const result = await getArgs(execPath);
                 expect(result).toMatchSnapshot("result");
             },
         );
@@ -211,32 +213,32 @@ describe("getArgs", () => {
         test("annotate invalid", async () => {
             inputs.set("annotate", "invalid");
 
-            await expect(getArgs()).rejects.toThrowError('invalid value "invalid" for annotate');
+            await expect(getArgs(execPath)).rejects.toThrowError('invalid value "invalid" for annotate');
         });
 
         test("annotate invalid comma", async () => {
             inputs.set("annotate", "errors,all");
 
-            await expect(getArgs()).rejects.toThrowError('invalid value "all" in comma-separated annotate');
+            await expect(getArgs(execPath)).rejects.toThrowError('invalid value "all" in comma-separated annotate');
         });
 
         test("verifytypes", async () => {
             inputs.set("verify-types", "some.package");
             inputs.set("ignore-external", "true");
 
-            const result = await getArgs();
+            const result = await getArgs(execPath);
             expect(result).toMatchSnapshot("result");
         });
 
         test("version not found", async () => {
             inputs.set("version", "999.999.404");
-            await expect(getArgs()).rejects.toThrowError("version not found: 999.999.404");
+            await expect(getArgs(execPath)).rejects.toThrowError("version not found: 999.999.404");
         });
 
         test("cached", async () => {
             mockedTc.find.mockReturnValue(path.join(fakeRoot, "cached", "pyright"));
 
-            const result = await getArgs();
+            const result = await getArgs(execPath);
             expect(result).toMatchSnapshot("result");
             expect(mockedTc.cacheDir).toBeCalledTimes(0);
         });
@@ -244,7 +246,7 @@ describe("getArgs", () => {
         test("extra-args quotes", async () => {
             inputs.set("extra-args", `--foo --bar --baz="quoted value"`);
 
-            const result = await getArgs();
+            const result = await getArgs(execPath);
             expect(result).toMatchSnapshot("result");
 
             expect(mockedTc.downloadTool).toBeCalledWith(getNpmResponse(latestPyright).dist.tarball);
@@ -254,7 +256,7 @@ describe("getArgs", () => {
         test("extra-args malformed", async () => {
             inputs.set("extra-args", `--foo --bar --baz="quoted value" > /dev/null`);
 
-            await expect(getArgs()).rejects.toThrowError(
+            await expect(getArgs(execPath)).rejects.toThrowError(
                 'malformed extra-args: --foo --bar --baz="quoted value" > /dev/null',
             );
         });
@@ -262,49 +264,49 @@ describe("getArgs", () => {
         test("verifytypes flag", async () => {
             inputs.set("extra-args", "--verifytypes");
 
-            const result = await getArgs();
+            const result = await getArgs(execPath);
             expect(result).toMatchSnapshot("result");
         });
 
         test("verbose flag", async () => {
             inputs.set("extra-args", "--verbose");
 
-            const result = await getArgs();
+            const result = await getArgs(execPath);
             expect(result).toMatchSnapshot("result");
         });
 
         test("verbose", async () => {
             inputs.set("verbose", "TRUE");
 
-            const result = await getArgs();
+            const result = await getArgs(execPath);
             expect(result).toMatchSnapshot("result");
         });
 
         test("dependencies", async () => {
             inputs.set("dependencies", "TRUE");
 
-            const result = await getArgs();
+            const result = await getArgs(execPath);
             expect(result).toMatchSnapshot("result");
         });
 
         test("createstub", async () => {
             inputs.set("create-stub", "pygame");
 
-            const result = await getArgs();
+            const result = await getArgs(execPath);
             expect(result).toMatchSnapshot("result");
         });
 
         test("skip-unannotated", async () => {
             inputs.set("skip-unannotated", "TRUE");
 
-            const result = await getArgs();
+            const result = await getArgs(execPath);
             expect(result).toMatchSnapshot("result");
         });
 
         test("stats", async () => {
             inputs.set("stats", "TRue");
 
-            const result = await getArgs();
+            const result = await getArgs(execPath);
             expect(result).toMatchSnapshot("result");
         });
 
@@ -314,7 +316,7 @@ describe("getArgs", () => {
             inputs.set("typeshed-path", "/path/to/typeshed");
             inputs.set("venv-path", "/path/to-venv");
 
-            const result = await getArgs();
+            const result = await getArgs(execPath);
             expect(result).toMatchSnapshot("result");
 
             expect(mockedTc.downloadTool).toBeCalledWith(getNpmResponse(version).dist.tarball);
@@ -327,7 +329,7 @@ describe("getArgs", () => {
             inputs.set("typeshed-path", "/path/to/typeshed");
             inputs.set("venv-path", "/path/to-venv");
 
-            const result = await getArgs();
+            const result = await getArgs(execPath);
             expect(result).toMatchSnapshot("result");
 
             expect(mockedTc.downloadTool).toBeCalledWith(getNpmResponse(version).dist.tarball);
@@ -340,7 +342,7 @@ describe("getArgs", () => {
             inputs.set("typeshed-path", "/path/to/typeshed");
             inputs.set("venv-path", "/path/to-venv");
 
-            const result = await getArgs();
+            const result = await getArgs(execPath);
             expect(result).toMatchSnapshot("result");
 
             expect(mockedTc.downloadTool).toBeCalledWith(getNpmResponse(version).dist.tarball);
@@ -349,14 +351,14 @@ describe("getArgs", () => {
 
         test("pylance-version not found", async () => {
             inputs.set("pylance-version", "9999.99.404");
-            await expect(getArgs()).rejects.toThrowError("version not found: 9999.99.404");
+            await expect(getArgs(execPath)).rejects.toThrowError("version not found: 9999.99.404");
         });
 
         test("pylance-version", async () => {
             const pylanceVersion = "2023.11.11";
             inputs.set("pylance-version", pylanceVersion);
 
-            const result = await getArgs();
+            const result = await getArgs(execPath);
             expect(result).toMatchSnapshot("result");
 
             expect(mockedTc.downloadTool).toBeCalledWith(getNpmResponse("9.9.999").dist.tarball);
@@ -368,7 +370,7 @@ describe("getArgs", () => {
             inputs.set("version", version);
             inputs.set("pylance-version", "2023.11.11");
 
-            const result = await getArgs();
+            const result = await getArgs(execPath);
             expect(result).toMatchSnapshot("result");
 
             expect(mockedTc.downloadTool).toBeCalledWith(getNpmResponse(version).dist.tarball);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -256,7 +256,7 @@ async function getPyrightInfo(): Promise<PyrightInfo> {
         const command = which.sync("pyright");
         const versionOut = cp.execFileSync(command, ["--version"], { encoding: "utf8" });
         const versionRaw = versionOut.trim().split(/\s+/).at(-1);
-        if (!versionRaw) throw new Error(`Failed to parse pyright version from ${versionOut}`);
+        if (!versionRaw) throw new Error(`Failed to parse pyright version from ${JSON.stringify(versionOut)}`);
         const version = new SemVer(versionRaw).format();
         return {
             kind: "path",

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -75,6 +75,7 @@ describe("no comments", () => {
             annotate: new Set(),
             workingDirectory: wd,
             pyrightVersion,
+            command: nodeExecPath,
             args,
         });
     });
@@ -114,6 +115,7 @@ describe("with comments", () => {
             annotate: new Set(["error", "warning"]),
             workingDirectory: "",
             pyrightVersion,
+            command: nodeExecPath,
             args,
         });
     });
@@ -234,6 +236,7 @@ describe("with comments", () => {
             annotate: new Set(["error"]),
             workingDirectory: "",
             pyrightVersion,
+            command: nodeExecPath,
             args,
         });
 
@@ -293,6 +296,7 @@ describe("with comments", () => {
             annotate: new Set(["error", "warning"]),
             workingDirectory: "",
             pyrightVersion,
+            command: nodeExecPath,
             args,
         });
 
@@ -424,6 +428,7 @@ describe("with overridden flags", () => {
             annotate: new Set(),
             workingDirectory: wd,
             pyrightVersion,
+            command: nodeExecPath,
             args: flags,
         });
 
@@ -447,6 +452,7 @@ describe("with overridden flags", () => {
             annotate: new Set(),
             workingDirectory: wd,
             pyrightVersion: "1.1.350",
+            command: nodeExecPath,
             args: flags,
         });
 
@@ -470,6 +476,7 @@ describe("with overridden flags", () => {
             annotate: new Set(),
             workingDirectory: wd,
             pyrightVersion: "1.1.351",
+            command: nodeExecPath,
             args: flags,
         });
 
@@ -493,6 +500,7 @@ describe("with overridden flags", () => {
             annotate: new Set(),
             workingDirectory: wd,
             pyrightVersion: "1.1.352",
+            command: nodeExecPath,
             args: flags,
         });
 
@@ -516,6 +524,7 @@ describe("with overridden flags", () => {
             annotate: new Set(),
             workingDirectory: wd,
             pyrightVersion: "1.1.353",
+            command: nodeExecPath,
             args: flags,
         });
 
@@ -539,6 +548,7 @@ describe("with overridden flags", () => {
             annotate: new Set(),
             workingDirectory: wd,
             pyrightVersion,
+            command: nodeExecPath,
             args: [...flags, "--project", "/some/path/to/pyrightconfig.json"],
         });
 
@@ -562,6 +572,7 @@ describe("with overridden flags", () => {
             annotate: new Set(),
             workingDirectory: wd,
             pyrightVersion,
+            command: nodeExecPath,
             args: [...flags, "--project", "/some/path/to"],
         });
 
@@ -585,6 +596,7 @@ describe("with overridden flags", () => {
             annotate: new Set(),
             workingDirectory: wd,
             pyrightVersion,
+            command: nodeExecPath,
             args: [...flags, "--project", "/some/path/to/pyrightconfig.json"],
         });
 
@@ -608,6 +620,7 @@ describe("with overridden flags", () => {
             annotate: new Set(),
             workingDirectory: wd,
             pyrightVersion,
+            command: nodeExecPath,
             args: flags,
         });
 
@@ -642,6 +655,7 @@ describe("with overridden flags", () => {
             annotate: new Set(),
             workingDirectory: wd,
             pyrightVersion,
+            command: nodeExecPath,
             args: flags,
         });
 


### PR DESCRIPTION
`version: PATH` instructs the action to instead look on `$PATH` for `pyright`. This is useful in situations where dev dependencies already install `pyright`, e.g. via PyPI.

```yml
- run: |
    python -m venv .venv
    source .venv/bin/activate
    pip install -r dev-requirements.txt # includes pyright
- run: echo "$PWD/.venv/bin" >> $GITHUB_PATH

- uses: jakebailey/pyright-action@v2
  with:
    version: PATH
```