### PR TITLE
fix: use relative paths to working directory in annotations

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -10078,7 +10078,7 @@ async function main() {
       actionsCommand.issueCommand(
         diag.severity,
         {
-          file: diag.file,
+          file: workingDirectory ? path2.relative(workingDirectory, diag.file) : diag.file,
           line: line + 1,
           col: col + 1
         },

--- a/src/__snapshots__/main.test.ts.snap
+++ b/src/__snapshots__/main.test.ts.snap
@@ -1570,3 +1570,82 @@ exports[`with overridden flags > pyproject.toml bad toml > process.chdir 1`] = `
   ],
 ]
 `;
+
+exports[`working-directory > relative paths > command.issueCommand 1`] = `
+[
+  [
+    "error",
+    {
+      "col": 1,
+      "file": "file1.py",
+      "line": 1,
+    },
+    "some error",
+  ],
+]
+`;
+
+exports[`working-directory > relative paths > core.error 1`] = `[]`;
+
+exports[`working-directory > relative paths > core.info 1`] = `
+[
+  [
+    "pyright 1.1.240, node v20.8.1, pyright-action 1.1.0",
+  ],
+  [
+    "Working directory: /some/wd",
+  ],
+  [
+    "Running: /path/to/node /path/to/pyright/dist/index.js --outputjson",
+  ],
+  [
+    "/some/wd/file1.py:1:1 - error: some error",
+  ],
+  [
+    "1 error, 0 warnings, 0 informations",
+  ],
+]
+`;
+
+exports[`working-directory > relative paths > core.setFailed 1`] = `
+[
+  [
+    "1 error",
+  ],
+]
+`;
+
+exports[`working-directory > relative paths > core.warning 1`] = `[]`;
+
+exports[`working-directory > relative paths > cp.spawnSync 1`] = `
+[
+  [
+    "/path/to/node",
+    [
+      "/path/to/pyright/dist/index.js",
+      "--outputjson",
+    ],
+    {
+      "encoding": "utf8",
+      "maxBuffer": 104857600,
+      "stdio": [
+        "ignore",
+        "pipe",
+        "inherit",
+      ],
+    },
+  ],
+]
+`;
+
+exports[`working-directory > relative paths > fs.existsSync 1`] = `[]`;
+
+exports[`working-directory > relative paths > fs.readFileSync 1`] = `[]`;
+
+exports[`working-directory > relative paths > process.chdir 1`] = `
+[
+  [
+    "/some/wd",
+  ],
+]
+`;

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -687,6 +687,49 @@ describe("with overridden flags", () => {
     });
 });
 
+describe("working-directory", () => {
+    test("relative paths", async () => {
+        const args = ["/path/to/pyright/dist/index.js", "--outputjson"];
+        const wd = "/some/wd";
+
+        mockedHelpers.getArgs.mockResolvedValue({
+            annotate: new Set(["error"]),
+            workingDirectory: wd,
+            pyrightVersion,
+            command: nodeExecPath,
+            args,
+        });
+
+        mockedCp.spawnSync.mockImplementation(() => ({
+            pid: -1,
+            output: [],
+            stdout: reportToString({
+                generalDiagnostics: [
+                    {
+                        file: "/some/wd/file1.py",
+                        range: {
+                            start: { line: 0, character: 0 },
+                            end: { line: 1, character: 1 },
+                        },
+                        severity: "error",
+                        message: "some error",
+                    },
+                ],
+                summary: {
+                    errorCount: 1,
+                    warningCount: 0,
+                    informationCount: 0,
+                },
+            }) as any,
+            stderr: "" as any,
+            status: 1,
+            signal: null,
+        }));
+
+        await main();
+    });
+});
+
 function reportToString(report: Report): string {
     return JSON.stringify(report);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -93,7 +93,9 @@ export async function main() {
             actionsCommand.issueCommand(
                 diag.severity,
                 {
-                    file: diag.file,
+                    file: workingDirectory
+                        ? path.relative(workingDirectory, diag.file)
+                        : diag.file,
                     line: line + 1,
                     col: col + 1,
                 },


### PR DESCRIPTION
pyright outputs absolute paths in diagnostics and that's what is currently provided when creating GitHub annotations.

When a working directory is provided, which is outside of the GitHub workspace path, annotations would show up in the workflow summary, but wouldn't appear in the diff.

This PR changes the absolute paths in annotations to relative to the specified working directory to fix this problem.

Absolute paths will still be reported when `working-directory` is omitted. I tried to change that, but some tests failed and I didn't want to make broad changes.